### PR TITLE
Input schema

### DIFF
--- a/input_generation/generateBatchInput.ts
+++ b/input_generation/generateBatchInput.ts
@@ -2,8 +2,8 @@ const fs = require('fs')
 const path = require('path')
 
 const args = process.argv.slice(2)
-if (args.length != 2) {
-    console.error('Must provide a path to a hypar.json and a target output path.')
+if (args.length != 3) {
+    console.error('You must provide a path to a hypar.json, a target output path, and an input model path.')
     process.exit()
 }
 
@@ -20,13 +20,23 @@ if (path.extname(targetFile) != '.json') {
 }
 
 const configFile = JSON.parse(fs.readFileSync(hyparConfigPath))
-const parameters = configFile.inputs
+const parameters = configFile.input_schema.properties
+
+// TODO: Expand this to support multiple model import keys. Currently,
+// All model import keys will be set to the same model.
+var modelInputKeys = {}
+const inputModel = args[2]
+if (path.extname(inputModel) != '.json') {
+    console.error(`Input model must be a .json file. Currently: ${inputModel}`)
+    process.exit()
+}
+configFile.model_dependencies.map((md) => (modelInputKeys[md.name] = inputModel))
 
 // https://stackoverflow.com/questions/32439437/retrieve-an-evenly-distributed-number-of-elements-from-an-array
 function evenlyDistributedSubset(items, n) {
     var elements = [items[0]]
     var totalItems = items.length - 2
-    var interval = Math.floor(totalItems/(n - 2))
+    var interval = Math.floor(totalItems / (n - 2))
     for (var i = 1; i < n - 1; i++) {
         elements.push(items[i * interval])
     }
@@ -37,36 +47,62 @@ function evenlyDistributedSubset(items, n) {
 // Sample options on each axis
 const maxOptionsPerParam = 10
 const options = {}
-parameters.forEach((param) => {
-    switch (param.type) {
-        case 'geometry':
-            const vertices = [[0, 0], [40, 0], [40, 40], [0, 40]].map(([x, y]) => ({X: x, Y: y, Z: 0}))
-            options[param.name] = [{
-                discriminator: param.primitive_type == 'polyline' ? 'Elements.Geometry.Polyline' : 'Elements.Geometry.Polygon',
-                Vertices: vertices
-            }]
-            break
-        case 'range':
-            const rangeLength = Math.floor((param.max - param.min) / param.step) + 1
-            const fullRange = Array.from({ length: rangeLength }, (_, i) => param.min + (i * param.step))
-            options[param.name] = evenlyDistributedSubset(fullRange, Math.min(maxOptionsPerParam, fullRange.length))
-            break
-        default:
-            throw new Error(`Cannot generate options for param type ${param.type} (${param.name})`)
+Object.keys(parameters).forEach(key => {
+    const param = parameters[key]
+
+    // Parameters that are built-in like number and string.
+    if (param.type) {
+        switch (param.type) {
+            case 'number':
+                const rangeLength = Math.floor((param.maximum - param.minimum) / param.step) + 1
+                const fullRange = Array.from({ length: rangeLength }, (_, i) => param.minimum + (i * param.step))
+                options[key] = evenlyDistributedSubset(fullRange, Math.min(maxOptionsPerParam, fullRange.length))
+                break
+            default:
+                throw new Error(`Cannot generate options for param type ${param.type} (${key})`)
+        }
+        // Parameters that defined by schemas.
+    } else if (param.$ref) {
+        const vertices = [[0, 0], [40, 0], [40, 40], [0, 40]].map(([x, y]) => ({ X: x, Y: y, Z: 0 }))
+        switch (param.$ref) {
+            case 'https://hypar.io/Schemas/Geometry/Polyline.json':
+                options[key] = [{
+                    discriminator: 'Elements.Geometry.Polyline',
+                    Vertices: vertices,
+                }]
+                break
+            case 'https://hypar.io/Schemas/Geometry/Polygon.json':
+                options[key] = [{
+                    discriminator: 'Elements.Geometry.Polygon',
+                    Vertices: vertices,
+                }]
+                break
+            case 'https://hypar.io/Schemas/Geometry/Color.json':
+                options[key] = [{
+                    discriminator: 'Elements.Geometry.Color',
+                    Color: { Red: 1.0, Green: 1.0, Blue: 1.0, Alpha: 1.0 }
+                }]
+                break
+            default:
+                throw new Error(`Cannot generate options for param type ${param.$ref} (${key})`)
+        }
     }
 })
 
 const executions = []
 const assignExecutions = function (paramIndex, executionParams) {
-    const param = parameters[paramIndex]
-    options[param.name].forEach((option: any, idx) => {
+    const name = Object.keys(parameters)[paramIndex]
+    const length = Object.keys(parameters).length
+
+    options[name].forEach((option: any, idx) => {
         const newExecutionParams = {}
         Object.assign(newExecutionParams, executionParams)
-        newExecutionParams[param.name] = option
-        if (paramIndex < parameters.length - 1) {
+        newExecutionParams[name] = option
+        if (paramIndex < length - 1) {
             assignExecutions(paramIndex + 1, newExecutionParams)
         }
         else {
+            newExecutionParams['model_input_keys'] = modelInputKeys
             executions.push(newExecutionParams)
         }
     })

--- a/input_generation/generateBatchInput.ts
+++ b/input_generation/generateBatchInput.ts
@@ -80,7 +80,10 @@ Object.keys(parameters).forEach(key => {
             case 'https://hypar.io/Schemas/Geometry/Color.json':
                 options[key] = [{
                     discriminator: 'Elements.Geometry.Color',
-                    Color: { Red: 1.0, Green: 1.0, Blue: 1.0, Alpha: 1.0 }
+                    Red: 1.0,
+                    Green: 1.0,
+                    Blue: 1.0,
+                    Alpha: 1.0
                 }]
                 break
             default:

--- a/input_generation/generateBatchInput.ts
+++ b/input_generation/generateBatchInput.ts
@@ -2,8 +2,8 @@ const fs = require('fs')
 const path = require('path')
 
 const args = process.argv.slice(2)
-if (args.length != 3) {
-    console.error('You must provide a path to a hypar.json, a target output path, and an input model path.')
+if (args.length != 2) {
+    console.error('You must provide a path to a hypar.json, and a target output path.')
     process.exit()
 }
 
@@ -20,17 +20,21 @@ if (path.extname(targetFile) != '.json') {
 }
 
 const configFile = JSON.parse(fs.readFileSync(hyparConfigPath))
-const parameters = configFile.input_schema.properties
 
 // TODO: Expand this to support multiple model import keys. Currently,
 // All model import keys will be set to the same model.
-var modelInputKeys = {}
-const inputModel = args[2]
-if (path.extname(inputModel) != '.json') {
-    console.error(`Input model must be a .json file. Currently: ${inputModel}`)
-    process.exit()
+var modelInputKeys = null
+if (args.length > 2) {
+    const inputModel = args[2]
+    if (path.extname(inputModel) != '.json') {
+        console.error(`Input model must be a .json file. Currently: ${inputModel}`)
+        process.exit()
+    }
+    modelInputKeys = {}
+    if (configFile.model_dependencies) {
+        configFile.model_dependencies.map((md) => (modelInputKeys[md.name] = inputModel))
+    }
 }
-configFile.model_dependencies.map((md) => (modelInputKeys[md.name] = inputModel))
 
 // https://stackoverflow.com/questions/32439437/retrieve-an-evenly-distributed-number-of-elements-from-an-array
 function evenlyDistributedSubset(items, n) {
@@ -47,57 +51,86 @@ function evenlyDistributedSubset(items, n) {
 // Sample options on each axis
 const maxOptionsPerParam = 10
 const options = {}
-Object.keys(parameters).forEach(key => {
-    const param = parameters[key]
 
-    // Parameters that are built-in like number and string.
-    if (param.type) {
+var parameters = null
+
+// TODO: Remove this section when we are sure
+// that the majority of functions are using input_schema
+if (configFile.inputs) {
+    parameters = configFile.inputs
+    parameters.forEach((param) => {
         switch (param.type) {
-            case 'number':
-                const rangeLength = Math.floor((param.maximum - param.minimum) / param.step) + 1
-                const fullRange = Array.from({ length: rangeLength }, (_, i) => param.minimum + (i * param.step))
-                options[key] = evenlyDistributedSubset(fullRange, Math.min(maxOptionsPerParam, fullRange.length))
+            case 'geometry':
+                const vertices = [[0, 0], [40, 0], [40, 40], [0, 40]].map(([x, y]) => ({ X: x, Y: y, Z: 0 }))
+                options[param.name] = [{
+                    discriminator: param.primitive_type == 'polyline' ? 'Elements.Geometry.Polyline' : 'Elements.Geometry.Polygon',
+                    Vertices: vertices
+                }]
+                break
+            case 'range':
+                const rangeLength = Math.floor((param.max - param.min) / param.step) + 1
+                const fullRange = Array.from({ length: rangeLength }, (_, i) => param.min + (i * param.step))
+                options[param.name] = evenlyDistributedSubset(fullRange, Math.min(maxOptionsPerParam, fullRange.length))
                 break
             default:
-                throw new Error(`Cannot generate options for param type ${param.type} (${key})`)
+                throw new Error(`Cannot generate options for param type ${param.type} (${param.name})`)
         }
-        // Parameters that defined by schemas.
-    } else if (param.$ref) {
-        const vertices = [[0, 0], [40, 0], [40, 40], [0, 40]].map(([x, y]) => ({ X: x, Y: y, Z: 0 }))
-        switch (param.$ref) {
-            case 'https://hypar.io/Schemas/Geometry/Polyline.json':
-                options[key] = [{
-                    discriminator: 'Elements.Geometry.Polyline',
-                    Vertices: vertices,
-                }]
-                break
-            case 'https://hypar.io/Schemas/Geometry/Polygon.json':
-                options[key] = [{
-                    discriminator: 'Elements.Geometry.Polygon',
-                    Vertices: vertices,
-                }]
-                break
-            case 'https://hypar.io/Schemas/Geometry/Color.json':
-                options[key] = [{
-                    discriminator: 'Elements.Geometry.Color',
-                    Red: 1.0,
-                    Green: 1.0,
-                    Blue: 1.0,
-                    Alpha: 1.0
-                }]
-                break
-            default:
-                throw new Error(`Cannot generate options for param type ${param.$ref} (${key})`)
+    })
+} else {
+    parameters = configFile.input_schema.properties
+    Object.keys(parameters).forEach(key => {
+        const param = parameters[key]
+
+        // Parameters that are built-in like number and string.
+        if (param.type) {
+            switch (param.type) {
+                case 'number':
+                    const rangeLength = Math.floor((param.maximum - param.minimum) / param.step) + 1
+                    const fullRange = Array.from({ length: rangeLength }, (_, i) => param.minimum + (i * param.step))
+                    options[key] = evenlyDistributedSubset(fullRange, Math.min(maxOptionsPerParam, fullRange.length))
+                    break
+                default:
+                    throw new Error(`Cannot generate options for param type ${param.type} (${key})`)
+            }
+            // Parameters that defined by schemas.
+        } else if (param.$ref) {
+            const vertices = [[0, 0], [40, 0], [40, 40], [0, 40]].map(([x, y]) => ({ X: x, Y: y, Z: 0 }))
+            switch (param.$ref) {
+                case 'https://hypar.io/Schemas/Geometry/Polyline.json':
+                    options[key] = [{
+                        discriminator: 'Elements.Geometry.Polyline',
+                        Vertices: vertices,
+                    }]
+                    break
+                case 'https://hypar.io/Schemas/Geometry/Polygon.json':
+                    options[key] = [{
+                        discriminator: 'Elements.Geometry.Polygon',
+                        Vertices: vertices,
+                    }]
+                    break
+                case 'https://hypar.io/Schemas/Geometry/Color.json':
+                    options[key] = [{
+                        discriminator: 'Elements.Geometry.Color',
+                        Red: 1.0,
+                        Green: 1.0,
+                        Blue: 1.0,
+                        Alpha: 1.0
+                    }]
+                    break
+                default:
+                    throw new Error(`Cannot generate options for param type ${param.$ref} (${key})`)
+            }
         }
-    }
-})
+    })
+}
 
 const executions = []
 const assignExecutions = function (paramIndex, executionParams) {
-    const name = Object.keys(parameters)[paramIndex]
-    const length = Object.keys(parameters).length
 
-    options[name].forEach((option: any, idx) => {
+    const name = configFile.inputs ? parameters[paramIndex].name : Object.keys(parameters)[paramIndex]
+    const length = configFile.inputs ? parameters.length : Object.keys(parameters).length
+
+    options[name].forEach((option: any) => {
         const newExecutionParams = {}
         Object.assign(newExecutionParams, executionParams)
         newExecutionParams[name] = option
@@ -105,7 +138,9 @@ const assignExecutions = function (paramIndex, executionParams) {
             assignExecutions(paramIndex + 1, newExecutionParams)
         }
         else {
-            newExecutionParams['model_input_keys'] = modelInputKeys
+            if (modelInputKeys) {
+                newExecutionParams['model_input_keys'] = modelInputKeys
+            }
             executions.push(newExecutionParams)
         }
     })

--- a/input_generation/package.json
+++ b/input_generation/package.json
@@ -8,7 +8,7 @@
   "author": "matt@hypar.io",
   "license": "MIT",
   "dependencies": {
-    "ts-node": "^8.9.0",
+    "ts-node": "^8.10.2",
     "typescript": "^3.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds support for `input_schema` in ML input generation. Only top level properties of types number, polyline, polygon, and color are currently supported. All other types with throw an exception during generation. This PR also adds the requirement to specify an input model file name on the command line which will be written into the `model_input_keys` for each input object. This supports the recently added capability on the CLI to pass input models to functions running locally in batch mode.

This has been tested with the current version of the Facade function. I was able to generate ~500 unique glbs before I killed the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/ml/2)
<!-- Reviewable:end -->
