### PR TITLE
Use multipleOf instead of step.

### DIFF
--- a/input_generation/generateBatchInput.ts
+++ b/input_generation/generateBatchInput.ts
@@ -130,8 +130,8 @@ if (configFile.inputs) {
                     options[key] = [true, false]
                     break
                 case 'number':
-                    const rangeLength = Math.floor((param.maximum - param.minimum) / param.step) + 1
-                    const fullRange = Array.from({ length: rangeLength }, (_, i) => param.minimum + (i * param.step))
+                    const rangeLength = Math.floor((param.maximum - param.minimum) / param.multipleOf) + 1
+                    const fullRange = Array.from({ length: rangeLength }, (_, i) => param.minimum + (i * param.multipleOf))
                     options[key] = evenlyDistributedSubset(fullRange, Math.min(maxOptionsPerParam, fullRange.length))
                     break
                 case 'string':


### PR DESCRIPTION
This PR resolves one, but probably not all, of the issues with generating inputs. We no longer use `step` in input schemas. We use `multipleOf`. This was not recognized and it caused all numeric inputs to be skipped. 